### PR TITLE
Changed CD Dockerrun.aws.json

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -67,7 +67,7 @@ jobs:
           version_label: ${{steps.build-number.outputs.BUILD_NUMBER }}
           version_description: ${{github.SHA }}
           region: ${{ secrets.EB_REGION }}
-          deployment_package: Dockerrun.aws.json
+          deployment_package: backend/Dockerrun.aws.json
 
       - name: Commit and push Dockerrun.aws.json
         run: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update deployment_package path from Dockerrun.aws.json to backend/Dockerrun.aws.json in the backend-cd GitHub Actions workflow