### PR TITLE
last name Docker commit and push Dockerrun.aws.json

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -76,8 +76,6 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-
           git add . 
           git commit -m "Update Dockerrun.aws.json docker image with new tag ${{steps.build-number.outputs.BUILD_NUMBER }}" || echo "No changes to commit"
           git push


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove `git remote set-url origin` step that injected the access token into the remote URL