### PR TITLE
add Slack and PingPong Counter

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -29,6 +29,13 @@ jobs:
       run:
         working-directory: ./backend
     steps:
+      - name: Send Slack Message
+        run: >
+          curl && curl -X POST -H 'Content-type: application/json'
+          --data '
+            {"text":"Deployment started postgress_bar: :fingerscrossed:"}
+          '
+          &{{secrets.SLACK_WEBHOOK_URL}}
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
@@ -44,8 +51,25 @@ jobs:
       - name: Set build number
         id : build-number
         run: echo "BUILD_NUMBER=$(date '+%d.%m.%Y.%H.%M.%S')" >> $GITHUB_OUTPUT
+
+      - name: Send Slack Message
+        run: >
+          curl && curl -X POST -H 'Content-type: application/json'
+          --data '
+            {"text":":maven: Building with Maven"}
+          '
+          &{{secrets.SLACK_WEBHOOK_URL}}
+
       - name: Build Package Push with Maven
         run: mvn -ntp -B verify -Ddocker.image.tag=${{ steps.build-number.outputs.BUILD_NUMBER}} jib:build
+
+      - name: Send Slack Message
+        run: >
+          curl && curl -X POST -H 'Content-type: application/json'
+          --data '
+            {"text":":docker: Image tag :${{ steps.build-number.outputs.BUILD_NUMBER}} pushed to https://hub.docker.com/repository/docker/shermatov/amigoscode-api"}
+          '
+          &{{secrets.SLACK_WEBHOOK_URL}}
 
 
       - name: Update Dockerrun.aws.json api image tag with build number
@@ -55,6 +79,14 @@ jobs:
           sed -i -E "s_(shermatov/amigoscode-api:)([^\"]*)_\1${{ steps.build-number.outputs.BUILD_NUMBER }}_" Dockerrun.aws.json
           echo "Dockerrun.aws.json after updating seg"
           cat Dockerrun.aws.json
+
+      - name: Send Slack Message
+        run: >
+          curl && curl -X POST -H 'Content-type: application/json'
+          --data '
+            {"text":":aws: Starting deployment to Elastic Beanstalk"}
+          '
+          &{{secrets.SLACK_WEBHOOK_URL}}
       
 
       - name: Deploy to Elastic Beanstalk
@@ -72,6 +104,15 @@ jobs:
           region: ${{ secrets.EB_REGION }}
           deployment_package: backend/Dockerrun.aws.json
 
+
+      - name: Send Slack Message
+        run: >
+          curl && curl -X POST -H 'Content-type: application/json'
+          --data '
+            {"text":":githubloading: Commiting to repo https://github.com/shermatov/amigoscode-api"}
+          '
+          &{{secrets.SLACK_WEBHOOK_URL}}
+
       - name: Commit and push Dockerrun.aws.json
         run: |
           git config user.name github-actions
@@ -79,6 +120,22 @@ jobs:
           git add . 
           git commit -m "Update Dockerrun.aws.json docker image with new tag ${{steps.build-number.outputs.BUILD_NUMBER }}" || echo "No changes to commit"
           git push
+
+      - name: Send Slack Message
+        run: >
+          curl && curl -X POST -H 'Content-type: application/json'
+          --data '
+            {"text":"Deployment and commit completed :github_check_mar: :party_blob: - ${{secrets.EB_ENVIRONMENT_URL}}"}
+          '
+          &{{secrets.SLACK_WEBHOOK_URL}}
+
+      - name: Send Slack Message
+        run: >
+          curl && curl -X POST -H 'Content-type: application/json'
+          --data '
+            {"text":"Job Status ${{job.status}}"}
+          '
+          &{{secrets.SLACK_WEBHOOK_URL}}
           
       
 

--- a/backend/src/main/java/com/shermatov/PingPongController.java
+++ b/backend/src/main/java/com/shermatov/PingPongController.java
@@ -6,8 +6,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class PingPongController {
 
+    private static int COUNTER = 0;
+
     @GetMapping("/ping")
     public PingPong getPingPong(){
-        return new PingPong("Pong");
+        return new PingPong("Pong" + ++COUNTER);
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Integrate Slack notifications into the backend CI/CD workflow and add a simple request counter to the /ping endpoint.

New Features:
- Add Slack messages at key stages of the backend deployment pipeline (start, build, image push, deployment, commit, and job status).
- Introduce a static counter in the PingPongController to append an incremental counter to each Pong response.